### PR TITLE
deploy dripper for quarter 3

### DIFF
--- a/scripts/refillers/deploy_autonomous_dripper.py
+++ b/scripts/refillers/deploy_autonomous_dripper.py
@@ -13,13 +13,10 @@ def main(deployer_label=None):
         return AutonomousDripper.deploy(
             registry.eth.badger_wallets.techops_multisig, # address initialOwner
             registry.eth.badger_wallets.badgertree, # address beneficiaryAddress
-            timegm(date(2022, 5, 20).timetuple()), # uint64 startTimestamp
-            int(timedelta(weeks=6).total_seconds()), # uint64 durationSeconds
+            timegm(date(2022, 7, 1).timetuple()), # uint64 startTimestamp
+            int(timedelta(weeks=13).total_seconds()), # uint64 durationSeconds
             60*60*24*7, # uint intervalSeconds
-            [
-                registry.eth.treasury_tokens.BADGER,
-                registry.eth.treasury_tokens.DIGG,
-            ], # address[] memory watchlistAddresses
+            [registry.eth.treasury_tokens.BADGER], # address[] memory watchlistAddresses
             registry.eth.chainlink.keeper_registry, # address keeperRegistryAddress
             {'from': deployer},
             publish_source=on_live_network

--- a/scripts/refillers/deploy_emissions_dripper.py
+++ b/scripts/refillers/deploy_emissions_dripper.py
@@ -13,7 +13,7 @@ def main(deployer_label=None):
         return EmissionsDripper.deploy(
             registry.eth.sett_vaults.remBADGER,
             timegm(date(2022, 4, 29).timetuple()),
-            int(timedelta(weeks=9).total_seconds()),
+            int(timedelta(weeks=99).total_seconds()),
             registry.eth.badger_wallets.techops_multisig,
             registry.eth.badger_wallets.dev_multisig,
             deployer,

--- a/tests/refillers/drippers/test_autonomous_dripper.py
+++ b/tests/refillers/drippers/test_autonomous_dripper.py
@@ -121,6 +121,7 @@ def test_perform_upkeep(dripper, badger, keeper):
 
 
 def test_perform_upkeep_multiple_tokens(dripper, badger, digg, keeper):
+    dripper.setAssetsWatchlist([badger, digg], {'from': dripper.owner()})
     badger._mint_for_testing(dripper, 100_000 * 10**badger.decimals())
     digg._mint_for_testing(dripper, 10 * 10**digg.decimals())
     chain.sleep(dripper.interval())


### PR DESCRIPTION
this also solves #4---it will just need `registry.eth.badger_wallets.remBADGER` for the `beneficiaryAddress` param.