### PR TITLE
Registry ACL

### DIFF
--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -23,7 +23,8 @@ the Badger Registry V2.
 
 References:
 BadgerRegistry repo: https://github.com/Badger-Finance/badger-registry
-*/
+**/
+
 contract RegistryAccessControl is AccessControlUpgradeable {
     // Registery Roles
     bytes32 public constant DEVELOPER_ROLE = keccak256("DEVELOPER_ROLE");

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -17,7 +17,7 @@ import "interfaces/badger/IBadgerRegistryV2.sol";
     function as the Registry's "developer" actor - can promote to experimental and demote vaults
     in a quick fashion.
 
-@notice: For promote() and demote() to work, this contract must be set as the "developer" on
+@notice For promote() and demote() to work, this contract must be set as the "developer" on
 the Badger Registry V2.
 
 References:

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -4,6 +4,26 @@ pragma solidity 0.6.12;
 import "deps/@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "interfaces/badger/IBadgerRegistryV2.sol";
 
+/**
+RegistryAccessControl
+Written by Saj for BadgerDAO
+
+Description:
+ACL proxy for the Badger Registry V2. This contract serves two purposes:
+    - Allows for the addition/removal of experimental vaults to the Registry
+    from a single address. Vaults indexed to this contract's address will be displayed on the
+    UI as experimental. This is to avoid having to keep track of all deployer's addresses
+    and maintaining that list off-chain.
+    - Allows for multiple developers (with the list controlled by the contract's admin), to
+    function as the Registry's "developer" actor - can promote to experimental and demote vaults
+    in a quick fashion.
+
+NOTE: For promote() and demote() to work, this contract must be set as the "developer" on
+the Badger Registry V2.
+
+References:
+BadgerRegistry repo: https://github.com/Badger-Finance/badger-registry
+*/
 contract RegistryAccessControl is AccessControlUpgradeable {
     // Registery Roles
     bytes32 public constant DEVELOPER_ROLE = keccak256("DEVELOPER_ROLE");

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -29,20 +29,11 @@ contract RegistryAccessControl is AccessControlUpgradeable {
     bytes32 public constant DEVELOPER_ROLE = keccak256("DEVELOPER_ROLE");
 
     // Addresses
-    IBadgerRegistryV2 public registry;
+    IBadgerRegistryV2 public constant registry = IBadgerRegistryV2(0xdc602965F3e5f1e7BAf2446d5564b407d5113A06);
 
-    function initialize(address initialAdmin_, address registry_) external initializer {
+    function initialize(address initialAdmin_) external initializer {
         __AccessControl_init();
         _setupRole(DEFAULT_ADMIN_ROLE, initialAdmin_);
-        registry = IBadgerRegistryV2(registry_);
-    }
-
-    // ===== Permissioned Functions: DEFAULT_ADMIN_ROLE =====
-
-    /// @dev Changes the address of the Registry
-    function setRegistry(address registry_) external {
-        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "DEFAULT_ADMIN_ROLE");
-        registry = IBadgerRegistryV2(registry_);
     }
 
     // ===== Permissioned Functions: Developer =====

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -38,6 +38,12 @@ contract RegistryAccessControl is AccessControlUpgradeable {
         registry.add(vault, version, metadata);
     }
 
+    /// @dev Remove the vault from this contract's address index
+    function remove(address vault) external {
+        require(hasRole(DEVELOPER_ROLE, msg.sender), "DEVELOPER_ROLE");
+        registry.remove(vault);
+    }
+
     /// @dev Promote a vault to Production on the Registry
     /// @notice Promote just means indexed by the Governance Address
     /// @notice Should this contract be set as the "developer" on the registry it will be able

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -5,11 +5,10 @@ import "deps/@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable
 import "interfaces/badger/IBadgerRegistryV2.sol";
 
 /**
-RegistryAccessControl
-Written by Saj for BadgerDAO
+@title RegistryAccessControl
+@author Saj @ BadgerDAO
 
-Description:
-ACL proxy for the Badger Registry V2. This contract serves two purposes:
+@dev ACL proxy for the Badger Registry V2. This contract serves two purposes:
     - Allows for the addition/removal of experimental vaults to the Registry
     from a single address. Vaults indexed to this contract's address will be displayed on the
     UI as experimental. This is to avoid having to keep track of all deployer's addresses
@@ -18,12 +17,12 @@ ACL proxy for the Badger Registry V2. This contract serves two purposes:
     function as the Registry's "developer" actor - can promote to experimental and demote vaults
     in a quick fashion.
 
-NOTE: For promote() and demote() to work, this contract must be set as the "developer" on
+@notice: For promote() and demote() to work, this contract must be set as the "developer" on
 the Badger Registry V2.
 
 References:
 BadgerRegistry repo: https://github.com/Badger-Finance/badger-registry
-**/
+*/
 
 contract RegistryAccessControl is AccessControlUpgradeable {
     // Registery Roles

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -65,7 +65,6 @@ contract RegistryAccessControl is AccessControl {
         IBadgerRegistryV2.VaultStatus status
     ) external {
         require(hasRole(DEVELOPER_ROLE, msg.sender), "DEVELOPER_ROLE");
-        require(registry.developer() == address(this), "Developer not set");
         registry.promote(vault, version, metadata, status);
     }
 
@@ -73,7 +72,6 @@ contract RegistryAccessControl is AccessControl {
     /// @notice This call will only work if this contract is set as the "developer" on the registry
     function demote(address vault, IBadgerRegistryV2.VaultStatus status) external {
         require(hasRole(DEVELOPER_ROLE, msg.sender), "DEVELOPER_ROLE");
-        require(registry.developer() == address(this), "Developer not set");
         registry.demote(vault, status);
     }
 }

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "deps/@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "interfaces/badger/IBadgerRegistryV2.sol";
+
+contract RegistryAccessControl is AccessControlUpgradeable {
+    // Registery Roles
+    bytes32 public constant DEVELOPER_ROLE = keccak256("DEVELOPER_ROLE");
+
+    // Addresses
+    IBadgerRegistryV2 public registry;
+
+    function initialize(address initialAdmin_, address registry_) external initializer {
+        __AccessControl_init();
+        _setupRole(DEFAULT_ADMIN_ROLE, initialAdmin_);
+        registry = IBadgerRegistryV2(registry_);
+    }
+
+    // ===== Permissioned Functions: DEFAULT_ADMIN_ROLE =====
+
+    /// @dev Changes the address of the Registry
+    function setRegistry(address registry_) external {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "DEFAULT_ADMIN_ROLE");
+        registry = IBadgerRegistryV2(registry_);
+    }
+
+    // ===== Permissioned Functions: Developer =====
+
+    /// @dev Add a vault to the registry under this contract's address
+    /// @notice The vault will be indexed under this contract's address
+    function add(
+        address vault,
+        string memory version,
+        string memory metadata
+    ) external {
+        require(hasRole(DEVELOPER_ROLE, msg.sender), "DEVELOPER_ROLE");
+        registry.add(vault, version, metadata);
+    }
+
+    /// @dev Promote a vault to Production on the Registry
+    /// @notice Promote just means indexed by the Governance Address
+    /// @notice Should this contract be set as the "developer" on the registry it will be able
+    /// to promote up to experimental, otherwise this function will revert due to permissions.
+    function promote(
+        address vault,
+        string memory version,
+        string memory metadata,
+        IBadgerRegistryV2.VaultStatus status
+    ) external {
+        require(hasRole(DEVELOPER_ROLE, msg.sender), "DEVELOPER_ROLE");
+        require(registry.developer() == address(this), "Developer not set");
+        registry.promote(vault, version, metadata, status);
+    }
+
+    /// @dev Demotes a vault to a lower status
+    /// @notice This call will only work if this contract is set as the "developer" on the registry
+    function demote(address vault, IBadgerRegistryV2.VaultStatus status) external {
+        require(hasRole(DEVELOPER_ROLE, msg.sender), "DEVELOPER_ROLE");
+        require(registry.developer() == address(this), "Developer not set");
+        registry.demote(vault, status);
+    }
+}

--- a/contracts/registerAccessControl/RegistryAccessControl.sol
+++ b/contracts/registerAccessControl/RegistryAccessControl.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 
-import "deps/@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "deps/@openzeppelin/contracts/access/AccessControl.sol";
 import "interfaces/badger/IBadgerRegistryV2.sol";
 
 /**
@@ -24,16 +24,15 @@ References:
 BadgerRegistry repo: https://github.com/Badger-Finance/badger-registry
 */
 
-contract RegistryAccessControl is AccessControlUpgradeable {
+contract RegistryAccessControl is AccessControl {
     // Registery Roles
     bytes32 public constant DEVELOPER_ROLE = keccak256("DEVELOPER_ROLE");
 
     // Addresses
     IBadgerRegistryV2 public constant registry = IBadgerRegistryV2(0xdc602965F3e5f1e7BAf2446d5564b407d5113A06);
 
-    function initialize(address initialAdmin_) external initializer {
-        __AccessControl_init();
-        _setupRole(DEFAULT_ADMIN_ROLE, initialAdmin_);
+    constructor(address initialAdmin) public {
+        _setupRole(DEFAULT_ADMIN_ROLE, initialAdmin);
     }
 
     // ===== Permissioned Functions: Developer =====

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -304,8 +304,7 @@ ADDRESSES_ETH = {
         "SettV4h_V2": "0x4Da27cD2AE34a9E1776Ed01747A071C17Fa0b2Cf", # V2 -> governanceOrStrategist approve/revoke + sweep
         "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9", # V1.1 -> Beneficiary: devMulti
         "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C", # V1.1
-        "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa", # V1.1
-        "BadgerRegistryV2": "0x00000b7665850F6b1E99447a68dB1e83d8Deafe3"
+        "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa" # V1.1
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -304,7 +304,7 @@ ADDRESSES_ETH = {
         "SettV4h_V2": "0x4Da27cD2AE34a9E1776Ed01747A071C17Fa0b2Cf", # V2 -> governanceOrStrategist approve/revoke + sweep
         "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9", # V1.1 -> Beneficiary: devMulti
         "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C", # V1.1
-        "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa" # V1.1
+        "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa", # V1.1
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -305,6 +305,7 @@ ADDRESSES_ETH = {
         "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9", # V1.1 -> Beneficiary: devMulti
         "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C", # V1.1
         "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa", # V1.1
+        "BadgerRegistryV2": "0x00000b7665850F6b1E99447a68dB1e83d8Deafe3"
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",

--- a/interfaces/badger/IBadgerRegistryV2.sol
+++ b/interfaces/badger/IBadgerRegistryV2.sol
@@ -40,6 +40,7 @@ interface IBadgerRegistryV2 {
 		VaultMetadata[] list;
 	}
 
+	function initialize(address newGovernance, address newStrategistGuild) external;
 	function setGovernance(address _newGov) external;
 	function setDeveloper(address newDev) external;
 	function setStrategistGuild(address newStrategistGuild) external;
@@ -49,6 +50,7 @@ interface IBadgerRegistryV2 {
 		string memory version,
 		string memory metadata
 	) external;
+	function remove(address vault) external;
 	function promote(
 		address vault,
 		string memory version,
@@ -61,7 +63,9 @@ interface IBadgerRegistryV2 {
 	function set(string memory key, address at) external;
 	function deleteKey(string memory key) external;
 	function deleteKeys(string[] memory _keys) external;
+	function governance() external view returns (address);
 	function developer() external view returns (address);
+	function strategistGuild() external view returns (address);
 	function get(string memory key) external view returns (address);
 	function keysCount() external view returns (uint256);
 	function getVaults(string memory version, address author) external view returns (VaultInfo[] memory);

--- a/interfaces/badger/IBadgerRegistryV2.sol
+++ b/interfaces/badger/IBadgerRegistryV2.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+interface IBadgerRegistryV2 {
+	event NewVault(address author, string version, string metadata, address vault);
+	event RemoveVault(address author, string version, string metadata, address vault);
+	event PromoteVault(address author, string version, string metadata, address vault, VaultStatus status);
+	event DemoteVault(address author, string version, string metadata, address vault, VaultStatus status);
+	event PurgeVault(address author, string version, string metadata, address vault, VaultStatus status);
+
+	event Set(string key, address at);
+	event AddKey(string key);
+	event DeleteKey(string key);
+	event AddVersion(string version);
+
+	enum VaultStatus {
+		deprecated,
+		experimental,
+		guarded,
+		open
+	}
+
+	struct VaultInfo {
+		address vault;
+		string version;
+		VaultStatus status;
+		string metadata;
+	}
+
+	struct VaultMetadata {
+		address vault;
+		string metadata;
+	}
+
+	struct VaultData {
+		string version;
+		VaultStatus status;
+		VaultMetadata[] list;
+	}
+
+	function setGovernance(address _newGov) external;
+	function setDeveloper(address newDev) external;
+	function setStrategistGuild(address newStrategistGuild) external;
+	function addVersions(string memory version) external;
+	function add(
+		address vault,
+		string memory version,
+		string memory metadata
+	) external;
+	function promote(
+		address vault,
+		string memory version,
+		string memory metadata,
+		VaultStatus status
+	) external;
+	function demote(address vault, VaultStatus status) external;
+	function purge(address vault) external;
+	function updateMetadata(address vault, string memory metadata) external;
+	function set(string memory key, address at) external;
+	function deleteKey(string memory key) external;
+	function deleteKeys(string[] memory _keys) external;
+	function developer() external view returns (address);
+	function get(string memory key) external view returns (address);
+	function keysCount() external view returns (uint256);
+	function getVaults(string memory version, address author) external view returns (VaultInfo[] memory);
+	function getFilteredProductionVaults(string memory version, VaultStatus status)
+		external
+		view
+		returns (VaultInfo[] memory);
+	function getProductionVaults() external view returns (VaultData[] memory);
+}

--- a/tests/registryACL/test_registry_access_control.py
+++ b/tests/registryACL/test_registry_access_control.py
@@ -33,7 +33,7 @@ def strategistGuild(registry_v2):
 @pytest.fixture(scope='module')
 def registry_acl(deployer, strategistGuild, registry_v2):
     contract = RegistryAccessControl.deploy({"from": deployer})
-    contract.initialize(strategistGuild.address, registry_v2.address, {"from": deployer})
+    contract.initialize(strategistGuild.address, {"from": deployer})
     return contract
 
 @pytest.fixture(scope='module', autouse=True)
@@ -167,17 +167,6 @@ def test_permissions(deployer2, deployer, strategistGuild, governance, registry_
         else:
             with brownie.reverts("AccessControl: sender must be an admin to grant"):
                 registry_acl.grantRole(role, rando.address, {"from": actor})
-
-    # setRegistry()
-    chain.snapshot()
-    for actor in actors:
-        if actor == strategistGuild:
-            registry_acl.setRegistry(RANDOM_ADDRESS, {"from": actor})
-            chain.revert()
-        else:
-            with brownie.reverts("DEFAULT_ADMIN_ROLE"):
-                registry_acl.setRegistry(RANDOM_ADDRESS, {"from": actor})
-
 
     ### RegistryACL not set as developer on Registry ###
 

--- a/tests/registryACL/test_registry_access_control.py
+++ b/tests/registryACL/test_registry_access_control.py
@@ -171,8 +171,8 @@ def test_permissions(deployer2, deployer, strategistGuild, governance, registry_
     registry_v2.setDeveloper(deployer, {"from": governance})
 
     # Promotions and demotions should fail
-    with brownie.reverts("Developer not set"):
+    with brownie.reverts("!auth"):
         registry_acl.demote(VAULT, 0, {"from": developers[0]})
     
-    with brownie.reverts("Developer not set"):
+    with brownie.reverts("!auth"):
         registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": developers[0]})

--- a/tests/registryACL/test_registry_access_control.py
+++ b/tests/registryACL/test_registry_access_control.py
@@ -180,7 +180,7 @@ def test_permissions(deployer2, deployer, strategistGuild, governance, registry_
 
 
     ### RegistryACL not set as developer on Registry ###
-    
+
     registry_v2.setDeveloper(deployer, {"from": governance})
 
     # Promotions and demotions should fail
@@ -188,8 +188,4 @@ def test_permissions(deployer2, deployer, strategistGuild, governance, registry_
         registry_acl.demote(VAULT, 0, {"from": developers[0]})
     
     with brownie.reverts("Developer not set"):
-        registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": developers[0]})
-
-
-
-    
+        registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": developers[0]})    

--- a/tests/registryACL/test_registry_access_control.py
+++ b/tests/registryACL/test_registry_access_control.py
@@ -1,0 +1,195 @@
+from datetime import datetime
+import brownie
+import pytest
+from brownie import accounts, interface, RegistryAccessControl, chain
+from helpers.addresses import registry
+
+### FIXTURES ###
+
+# Avoiding real vault addresses since the registry doesn't like duplicates
+VAULT = "0x1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a"
+RANDOM_ADDRESS = "0xb2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+
+@pytest.fixture(scope='module')
+def deployer():
+    return accounts[0]
+
+@pytest.fixture(scope='module')
+def deployer2():
+    return accounts[1]
+
+@pytest.fixture(scope='module')
+def registry_v2():
+    return interface.IBadgerRegistryV2(registry.eth.registry_v2)
+
+@pytest.fixture(scope='module')
+def governance(registry_v2):
+    return accounts.at(registry_v2.governance(), force=True)
+
+@pytest.fixture(scope='module')
+def strategistGuild(registry_v2):
+    return accounts.at(registry_v2.strategistGuild(), force=True)
+
+@pytest.fixture(scope='module')
+def registry_acl(deployer, strategistGuild, registry_v2):
+    contract = RegistryAccessControl.deploy({"from": deployer})
+    contract.initialize(strategistGuild.address, registry_v2.address, {"from": deployer})
+    return contract
+
+@pytest.fixture(scope='module', autouse=True)
+def state_setup(governance, strategistGuild, deployer, deployer2, registry_acl, registry_v2):
+    # Set registryACL as "developer" on registry
+    registry_v2.setDeveloper(registry_acl, {"from": governance})
+    # Add the deployers as developers on the ACL
+    role = registry_acl.DEVELOPER_ROLE()
+    registry_acl.grantRole(role, deployer.address, {"from": strategistGuild})
+    registry_acl.grantRole(role, deployer2.address, {"from": strategistGuild})
+
+### TESTS ###
+
+def test_add_remove(deployer, deployer2, registry_acl, registry_v2):
+    # No vaults have been added by deployer nor the ACL contract
+    assert registry_v2.getVaults("V1.5", registry_acl) == []
+    assert registry_v2.getVaults("V1.5", deployer) == []
+    assert registry_v2.getVaults("V1.5", deployer2) == []
+
+    # We add a vault through the ACL with the first deployer
+    tx = registry_acl.add(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", {"from": deployer})
+    assert registry_v2.getVaults("v1.5", registry_acl) == [[VAULT, "v1.5", "1", "name=BTC-CVX,protocol=Badger,behavior=DCA"]]
+    assert registry_v2.getVaults("V1.5", deployer) == []
+    assert registry_v2.getVaults("V1.5", deployer2) == []
+
+    event = tx.events["NewVault"][0]
+    assert event["author"] == registry_acl.address
+    assert event["vault"] == VAULT
+
+    # We remove the vault through the ACL using a different deployer
+    tx = registry_acl.remove(VAULT, {"from": deployer2})
+    assert registry_v2.getVaults("V1.5", registry_acl) == []
+    assert registry_v2.getVaults("V1.5", deployer) == []
+    assert registry_v2.getVaults("V1.5", deployer2) == []
+
+    event = tx.events["RemoveVault"][0]
+    assert event["author"] == registry_acl.address
+    assert event["vault"] == VAULT
+
+
+def test_promote(deployer, registry_acl, registry_v2):
+    # deployer attempts to promote to "Open" (3) but promotion is only possible to "experimental" (1)
+    tx = registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 3, {"from": deployer})
+    assert [VAULT, "v1.5", "1", "name=BTC-CVX,protocol=Badger,behavior=DCA"] not in registry_v2.getFilteredProductionVaults("v1.5", 3)
+    assert [VAULT, "v1.5", "1", "name=BTC-CVX,protocol=Badger,behavior=DCA"] in registry_v2.getFilteredProductionVaults("v1.5", 1)
+
+    event = tx.events["PromoteVault"][0]
+    assert event["author"] == registry_acl.address
+    assert event["vault"] == VAULT
+    assert event["status"] == 1
+
+
+def test_demote(deployer2, strategistGuild, registry_acl, registry_v2):
+    # strategistGuild promotes a vault to open (3)
+    registry_v2.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 3, {"from": strategistGuild})
+    assert [VAULT, "v1.5", "3", "name=BTC-CVX,protocol=Badger,behavior=DCA"] in registry_v2.getFilteredProductionVaults("v1.5", 3)
+
+    # deployer demotes vault to deprecated (0)
+    tx = registry_acl.demote(VAULT, 0, {"from": deployer2})
+    assert [VAULT, "v1.5", "0", "name=BTC-CVX,protocol=Badger,behavior=DCA"] not in registry_v2.getFilteredProductionVaults("v1.5", 3)
+    assert [VAULT, "v1.5", "0", "name=BTC-CVX,protocol=Badger,behavior=DCA"] in registry_v2.getFilteredProductionVaults("v1.5", 0)
+
+    event = tx.events["DemoteVault"][0]
+    assert event["author"] == registry_acl.address
+    assert event["vault"] == VAULT
+    assert event["status"] == 0
+
+
+def test_permissions(deployer2, deployer, strategistGuild, governance, registry_acl, registry_v2):
+    rando = accounts[5]
+    actors = [
+        deployer,
+        deployer2,
+        strategistGuild,
+        rando
+    ]
+
+    developers = [deployer, deployer2]
+
+    ### DEVELOPER_ROLE permissions ###
+
+    # add()
+    chain.snapshot() # Can't add the same vault twice
+    for actor in actors:
+        if actor in developers:
+            registry_acl.add(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", {"from": actor})
+            chain.revert()
+        else:
+            with brownie.reverts("DEVELOPER_ROLE"):
+                registry_acl.add(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", {"from": actor})
+
+    # remove()
+    registry_acl.add(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", {"from": deployer}) # We add a vault
+    chain.snapshot()
+    for actor in actors:
+        if actor in developers:
+            registry_acl.remove(VAULT, {"from": actor})
+            chain.revert()
+        else:
+            with brownie.reverts("DEVELOPER_ROLE"):
+                registry_acl.remove(VAULT, {"from": actor})
+
+    # promote()
+    for actor in actors:
+        if actor in developers:
+            registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": actor})
+            chain.revert()
+        else:
+            with brownie.reverts("DEVELOPER_ROLE"):
+                registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": actor})
+
+    # demote()
+    registry_v2.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 3, {"from": strategistGuild}) # Promote a vault
+    chain.snapshot()
+    for actor in actors:
+        if actor in developers:
+            registry_acl.demote(VAULT, 0, {"from": actor})
+            chain.revert()
+        else:
+            with brownie.reverts("DEVELOPER_ROLE"):
+                registry_acl.demote(VAULT, 0, {"from": actor})
+
+
+    ### DEFAULT_ADMIN_ROLE permissions ###
+
+    # grantRole()
+    for actor in actors:
+        role = registry_acl.DEVELOPER_ROLE()
+        if actor == strategistGuild:
+            registry_acl.grantRole(role, rando.address, {"from": actor})
+        else:
+            with brownie.reverts("AccessControl: sender must be an admin to grant"):
+                registry_acl.grantRole(role, rando.address, {"from": actor})
+
+    # setRegistry()
+    chain.snapshot()
+    for actor in actors:
+        if actor == strategistGuild:
+            registry_acl.setRegistry(RANDOM_ADDRESS, {"from": actor})
+            chain.revert()
+        else:
+            with brownie.reverts("DEFAULT_ADMIN_ROLE"):
+                registry_acl.setRegistry(RANDOM_ADDRESS, {"from": actor})
+
+
+    ### RegistryACL not set as developer on Registry ###
+    
+    registry_v2.setDeveloper(deployer, {"from": governance})
+
+    # Promotions and demotions should fail
+    with brownie.reverts("Developer not set"):
+        registry_acl.demote(VAULT, 0, {"from": developers[0]})
+    
+    with brownie.reverts("Developer not set"):
+        registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": developers[0]})
+
+
+
+    

--- a/tests/registryACL/test_registry_access_control.py
+++ b/tests/registryACL/test_registry_access_control.py
@@ -31,10 +31,8 @@ def strategistGuild(registry_v2):
     return accounts.at(registry_v2.strategistGuild(), force=True)
 
 @pytest.fixture(scope='module')
-def registry_acl(deployer, strategistGuild, registry_v2):
-    contract = RegistryAccessControl.deploy({"from": deployer})
-    contract.initialize(strategistGuild.address, {"from": deployer})
-    return contract
+def registry_acl(deployer, strategistGuild):
+    return RegistryAccessControl.deploy(strategistGuild.address, {"from": deployer})
 
 @pytest.fixture(scope='module', autouse=True)
 def state_setup(governance, strategistGuild, deployer, deployer2, registry_acl, registry_v2):
@@ -177,4 +175,4 @@ def test_permissions(deployer2, deployer, strategistGuild, governance, registry_
         registry_acl.demote(VAULT, 0, {"from": developers[0]})
     
     with brownie.reverts("Developer not set"):
-        registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": developers[0]})    
+        registry_acl.promote(VAULT, "v1.5", "name=BTC-CVX,protocol=Badger,behavior=DCA", 1, {"from": developers[0]})


### PR DESCRIPTION
Tackles issue https://github.com/Badger-Finance/badger-strategies/issues/70

ACL proxy for the Badger Registry V2. This contract serves two purposes:
    - Allows for the addition/removal of experimental vaults to the Registry
    from a single address. Vaults indexed to this contract's address will be displayed on the
    UI as experimental. This is to avoid having to keep track of all deployer's addresses
    and maintaining that list off-chain.
    - Allows for multiple developers (with the list controlled by the contract's admin), to
    function as the Registry's "developer" actor - can promote to experimental and demote vaults
    in a quick fashion.

NOTE: For promote() and demote() to work, this contract must be set as the "developer" on
the Badger Registry V2.

A test suite was included:
```
brownie test tests/registryACL/test_registry_access_control.py -s
```

All tests are passing:
![image](https://user-images.githubusercontent.com/25463788/179260275-8fa2418e-6294-4dc0-9220-58107c8e67f8.png)
