### PR TITLE
fix: confirm the asset to be released is actually on the watchlist

### DIFF
--- a/contracts/refillers/AutonomousDripper.sol
+++ b/contracts/refillers/AutonomousDripper.sol
@@ -82,6 +82,18 @@ contract AutonomousDripper is VestingWallet, KeeperCompatibleInterface, Confirme
     }
 
     /**
+     * @dev Confirms that the `asset` given exists in `assetsWatchlist`.
+     */
+    function _assetWatched(address asset) internal view returns (bool) {
+        for (uint idx = 0; idx < assetsWatchlist.length; idx++) {
+            if (assetsWatchlist[idx] == asset) {
+                return true;
+            }
+        }
+    return false;
+    }
+
+    /**
      * @dev Runs off-chain at every block to determine if the `performUpkeep`
      * function should be called on-chain.
      */
@@ -105,7 +117,10 @@ contract AutonomousDripper is VestingWallet, KeeperCompatibleInterface, Confirme
             address[] memory assetsHeld = abi.decode(performData, (address[]));
             bool dripped = false;
             for (uint idx = 0; idx < assetsHeld.length; idx++) {
-                if (IERC20(assetsHeld[idx]).balanceOf(address(this)) > 0) {
+                if (
+                    _assetWatched(assetsHeld[idx]) &&
+                    IERC20(assetsHeld[idx]).balanceOf(address(this)) > 0
+                ) {
                     VestingWallet.release(assetsHeld[idx]);
                     dripped = true;
                 }


### PR DESCRIPTION
just adds a tiny bit of security; there is a case imaginable in which a malicious keeper would pass a list of assets to release which actually arent on the watchlist at all.

closes #8 