### PR TITLE
chore: update deploy script for 2023

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -9,21 +9,35 @@ ADDRESSES_ETH = {
     "zero": "0x0000000000000000000000000000000000000000",
     "treasury": "0x8dE82C4C968663a0284b01069DDE6EF231D0Ef9B",
     "governance_timelock": "0x21CF9b77F88Adf8F8C98d7E33Fe601DC57bC0893",
-    "rewardsLogger" : "0x0A4F4e92C3334821EbB523324D09E321a6B0d8ec",
+    "rewardsLogger": "0x0A4F4e92C3334821EbB523324D09E321a6B0d8ec",
     "EmissionControl": "0x31825c0A6278b89338970e3eB979b05B27FAa263",
     "registry": "0xFda7eB6f8b7a9e9fCFd348042ae675d1d652454f",
     "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
+    "registryAccessControl": "0x1233A3885b8015f369287Ca53716F66cc755651c",
     "keeperAccessControl": "0x711A339c002386f9db409cA55b6A35a604aB6cF6",
     "guardian": "0x6615e67b8B6b6375D38A0A3f937cd8c1a1e96386",
     "GatedMiniMeController": "0xdDB2dfad74F64F14bb1A1cbaB9C03bc0eed74493",
     "GlobalAccessControl": "0x9c58B0D88578cd75154Bdb7C8B013f7157bae35a",
+    "harvest_forwarder": "0xA84B663837D94ec41B0f99903f37e1d69af9Ed3E",
     "badger_geyser": "0xBD9c69654B8F3E5978DFd138B00cB0Be29F28cCf",
+    "aragon_voting": "0xDc344bFB12522bF3fa58EF0d6b9a41256fc79A1b",
+    "badger_voting_shares": "0x49fa0D0619BdeD9aAc4106974E34CeB516bdeAeF",
+    "brickedProxyAdmin": "0x933FDBAc3773514384c6db30Eb196a0be543D617",
     "drippers": {
         "rembadger_2022_q2": "0xD87F434fE6d5B349f4376d2daBA762b213E403c7",
         "tree_2022_q2": "0xfA55d407F48849aE98a6e4f11Dc5C18E035F46Ec",
+        "rembadger_2022_q3": "0x697A8DebFbb6bE97c821b482AECc30477F40A102",
+        "tree_2022_q3": "0x5495BDB1f4c170e5C1A939382041Cf46d7f14EAd",
+        "rembadger_2022_q4": "0x9032618620fEDaC90990d4ba562ab0A86f5abaE7",
+        "tree_2022_q4": "0x7b222fBac58680c3456230b2e9f3E196512A9CF3",
     },
-    "bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
+    "safe_modules": {
+        "treasury_voter": "0xC485aFD2f3252cCB69d1c94392701d51013D42eB",
+    },
+    "cvx_bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
+    "aura_bribes_processor": "0x8ABD28E4D69bD3953b96dd9ED63533765AdB9965",
     "digg_monetary_policy": "0x327a78D13eA74145cc0C63E6133D516ad3E974c3",
+    "on_chain_pricing_mainnet_lenient": "0x2DC7693444aCd1EcA1D6dE5B3d0d8584F3870c49",
     # the wallets listed here are looped over by scout and checked for all treasury tokens
     "badger_wallets": {
         "fees": "0x8dE82C4C968663a0284b01069DDE6EF231D0Ef9B",
@@ -45,49 +59,58 @@ ADDRESSES_ETH = {
         "treasury_ops_multisig": "0x042B32Ac6b453485e357938bdC38e0340d4b9276",
         "treasury_vault_multisig": "0xD0A7A8B98957b9CD3cFB9c0425AbE44551158e9e",
         "ibbtc_multisig": "0xB76782B51BFf9C27bA69C77027e20Abd92Bcf3a8",
-        "bvecvx_voting_multisig": "0xA9ed98B5Fb8428d68664f3C5027c62A10d45826b",
+        "treasury_voter_multisig": "0xA9ed98B5Fb8428d68664f3C5027c62A10d45826b",
         "payments_multisig": "0x30a9c1D258F6c2D23005e6450E72bDD42C541105",
         "dfdBadgerShared": "0xCF7346A5E41b0821b80D5B3fdc385EEB6Dc59F44",
+        "mstableBadgerShared": "0xCa045cC466f14C33a516D98abcab5C55C2f5112c",
         "ops_deployer": "0xDA25ee226E534d868f0Dd8a459536b03fEE9079b",
         "ops_deployer2": "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556",
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
-        "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
         "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
-        "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
-        "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
+        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
+        # "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",  # can execute from deployer
         "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
-        "ops_executor4": "0xBB2281cA5B4d07263112604D1F182AD0Ab26a252",
-        "ops_executor5": "0xcDAb3AcC1AD3870a93BB72377092B67e290D76f3",
+        "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         "ops_executor6": "0x66496eBB9d848C6A8F19612a6Dd10E09954532D0",
-        "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",
-        "ops_executor8": "0x10C7a2ca16116E5C998Bfa3BC9CEF464475B18ff",
+        # "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",  # can execute from deployer
+        # "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",  # can execute from deployer
         # "ops_executor9": "0x69874C84a30A3742cC2b624238CfEEa24CF5eF82",
-        "ops_executor10": "0xaF94D299a73c4545ff702E79D16d9fb1AB5BDAbF",
+        # "ops_executor10": "0xaF94D299a73c4545ff702E79D16d9fb1AB5BDAbF",  # can execute from deployer
         # "ops_executor11": "0x54cf9df9dcd78e470ab7cb892d7bfbe114c025fc",
         # "ops_executor12": "0xD3cee5e327715Ad1195DcE8FD571c564cD2100E7",
-        "ops_root-validator-new": "0x1318d5c0C24830D86Cc27Db13Ced0CED31412438",
+        "ops_executor13": "0x95c1D2014909c04202fa73820B894b45F054F25e",
+        "ops_executor14": "0xE78e3E1668D42FfCa767e22e57d7d249e02B5F0e",
+        "ops_root-validator_v3": "0xcA63a374ec5f41dA402dD17b6d90DddFea3d64C4",
         "ops_botsquad": "0xF8dbb94608E72A3C4cEeAB4ad495ac51210a341e",
         "ops_botsquad_cycle0": "0x1a6D6D120a7e3F71B084b4023a518c72F1a93EE9",
         "digg_treasury": "0x5A54Ca44e8F5A1A695f8621f15Bfa159a140bB61",
         "uniswap_rewards": "0x0c79406977314847a9545b11783635432d7fe019",
         "defiDollar_fees": "0x5b5cf8620292249669e1dcc73b753d01543d6ac7",
+        "mStable_feesSplit": "0x01D5912c6001bc0892e2b1440B8E44fe736BAf8F",
         "delegate": "0x14f83ff95d4ec5e8812ddf42da1232b0ba1015e6",
         "devProxyAdmin": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF",
         "devUngatedProxyAdmin": "0x9215cBDCDe25629d0e3D69ee5562d1b444Cf69F9",
         "testProxyAdmin": "0xB10b3Af646Afadd9C62D663dd5d226B15C25CdFA",
         "techOpsProxyAdmin": "0x7D0398D7D7432c47Dffc942Cd097B9eA3d88C385",
         "opsProxyAdmin_old": "0x4599F2913a3db4E73aA77A304cCC21516dd7270D",
+        "mStableSharedProxyAdmin": "0x3cd782379cE010fcda43983B490A99f43AACE0c0",
         "badgerHunt": "0x394DCfbCf25C5400fcC147EbD9970eD34A474543",
         "rewardsEscrow": "0xBE838aE7f6Ba97e7Eb545a3f43eE96FfBb3184DC",
         "gas_station": "0x04C0205b9D900a49597d9a0345aEAD6D73307C3B",
         "_deprecated": {
+            "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+            "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
             "ops_deployer6": "0x7c1D678685B9d2F65F1909b9f2E544786807d46C",
+            "ops_executor4": "0xBB2281cA5B4d07263112604D1F182AD0Ab26a252",
+            "ops_executor5": "0xcDAb3AcC1AD3870a93BB72377092B67e290D76f3",
             "ops_guardian": "0x29F7F8896Fb913CF7f9949C623F896a154727919",
             "ops_keeper": "0x872213E29C85d7e30F1C8202FC47eD1Ec124BB1D",
             "ops_root-validator": "0x626f69162ea1556a75dd4443d87d2fe38dd25901",
+            "ops_root-validator-new": "0x1318d5c0C24830D86Cc27Db13Ced0CED31412438",
+            "ops_root-validator-old": "0x71e604d7db051eB7d9d0572dd06DbdB4435c9B1E",
             "ops_cycle_bot": "0x68de9E2b015904530593426d934CE608e117Fa7A",
             "ops_earner": "0x46099Ffa86aAeC689D11F5D5130044Ff7082C2AD",
             "ops_harvester": "0x73433896620E71f7b1C72405b8D2898e951Ca4d5",
@@ -117,10 +140,12 @@ ADDRESSES_ETH = {
         "DAI": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         "MIM": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
         "FRAX": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+        "aFRAX": "0xd4937682df3C8aEF4FE912A96A74121C0829E664",
         "FEI": "0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
         "DFD": "0x20c36f062a31865bED8a5B1e512D9a1A20AA333A",
         "CRV": "0xD533a949740bb3306d119CC777fa900bA034cd52",
         "WBTC": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "aWBTC": "0x9ff58f4fFB29fA2266Ab25e75e2A8b3503311656",
         "renBTC": "0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D",
         "sBTC": "0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6",
         "WETH": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
@@ -173,7 +198,17 @@ ADDRESSES_ETH = {
         "crv3eur": "0xb9446c4Ef5EBE66268dA6700D26f96273DE3d571",
         "FTM": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
         "BAL": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "BOR": "0x3c9d6c1C73b31c837832c72E04D3152f051fc1A9",
+        "BORING": "0xBC19712FEB3a26080eBf6f2F7849b417FdD792CA",
+        "PNT": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
         "LINK": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+        "AURA": "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+        "AURABAL": "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d",
+        "ANGLE": "0x31429d1856aD1377A8A0079410B297e1a9e214c2",
+        "badgerFRAXBP_f_lp": "0x09b2E090531228d1b8E3d948C73b990Cb6e60720",
+        "ENS": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+        "RETH": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+        "cvxFXS": "0xFEEf77d3f69374f66429C91d732A244f074bdf74",
     },
     # every slp token listed in treasury tokens above must also be listed here.
     # the lp_tokens in this list are processed by scount to determine holdings
@@ -223,6 +258,7 @@ ADDRESSES_ETH = {
         "badgerWBTC_f": "0x50f3752289e1456BfA505afd37B241bca23e685d",
         "t_eth_f": "0x752eBeb79963cf0732E9c0fec72a49FD1DEfAEAC",
         "cvx_eth_f": "0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4",
+        "badgerFRAXBP_f": "0x13B876C26Ad6d21cb87AE459EaF6d7A1b788A113",
     },
     # mStable want tokens
     "mstable_vaults": {
@@ -259,6 +295,14 @@ ADDRESSES_ETH = {
         "remBADGER": "0x6aF7377b5009d7d154F36FE9e235aE1DA27Aea22",
         "remDIGG": "0x99F39D495C6A5237f43602f3Ab5F49786E46c9B0",
         "bcrvBadger": "0xeC1c717A3b02582A4Aa2275260C583095536b613",
+        "graviAURA": "0xBA485b556399123261a5F9c95d413B4f93107407",
+        "bauraBal": "0x37d9D2C6035b744849C15F1BFEE8F268a20fCBd8",
+        "b80BADGER_20WBTC": "0x63ad745506BD6a3E57F764409A47ed004BEc40b1",
+        "b40WBTC_40DIGG_20graviAURA": "0x371B7C451858bd88eAf392B383Df8bd7B8955d5a",
+        "bBB_a_USD": "0x06D756861De0724FAd5B5636124e0f252d3C1404",
+        "b33auraBAL_33graviAURA_33WETH": "0xf8f5677B6bCecdb9be94AE8f6770a05a6C53C378",
+        "bB_stETH_STABLE": "0x41466b8ec544e3192Aa1aA30f65fC60FAb4D52Bf",
+        "bB-rETH-STABLE": "0xA484427CF91bbd945c39eF87dF0A02Bb8625dC97",
     },
     "strategies": {
         "native.badger": "0x75b8E21BD623012Efb3b69E1B562465A68944eE6",
@@ -288,23 +332,46 @@ ADDRESSES_ETH = {
         "native.bbveCVX-CVX-f": "0x98Ca7AFa876f0e15494E76E92C5b3658cdE1Ffe1",
         "native.bcrvIbBTC": "0x6D4BA00Fd7BB73b5aa5b3D6180c6f1B0c89f70D1",
         "native.remDigg": "0x4055D395361E73530D43c9D4F18b0668fe4B5b91",
-        "native.badgerCrv": "0x1905FD2D2D09792eE058C2b46a05F11630a1EcA1",
+        "native.bcrvBadger": "0x1905FD2D2D09792eE058C2b46a05F11630a1EcA1",
+        "native.graviAURA": "0x3c0989eF27e3e3fAb87a2d7C38B35880C90E63b5",
+        "native.bauraBal": "0x32BdF2B35Bbf8dAca3561C3ADE59c941488E9c69",
+        "native.b80BADGER_20WBTC": "0xe43857fE16D18b6633A663389934d6c64D5E81FD",
+        "native.b40WBTC_40DIGG_20graviAURA": "0xD87F2cdE238D0122b3865164359CFF6b2431d927",
+        "native.bB_stETH_STABLE": "0x1cC3731d8f30341EF4527E7da1B6a4DA88ef71DF",
+        "native.bB-rETH-STABLE": "0xE6153AdD9913c7D25a6d475acFfACc5Eb570D8bE",
+        "_deprecated": {
+            "native.bauraBal": {
+                "v1": "0xfB490b5beA343ABAe0E71B61bBdfd4301F5e4df9",
+                "v1.1": "0xED6d51A82065725e283fC035f488213e869FD976",
+            },
+            "native.pbtcCrv": {
+                "v1": "0x1C1fD689103bbFD701b3B7D41A3807F12814033D",
+                "v1.1": "0x3f98F3a21B125414e4740316bd6Ef14718764a22",
+            },
+            "native.obtcCrv": {
+                "v1": "0x2bb864cdb4856ab2d148c5ca52dd7ccec126d138",
+                "v1.1": "0x50Dd8A61Bdd11Cf5539DAA83Bc8E0F581eD8110a",
+            },
+        },
     },
     "logic": {
-        "StrategyConvexStakingOptimizer": "0x0bB87f40D4eb6066a2311B7BE3B45A3D15771557", # V1.1
-        "StrategyCvxHelper": "0x9A12A9141363A5B343B781c4951d42E327B89397", # V1.1
-        "StrategyCvxCrvHelper": "0x76328277232c97BAf76D23A69015CB478293A048", # V1.1
+        "StrategyConvexStakingOptimizer": "0x0bB87f40D4eb6066a2311B7BE3B45A3D15771557",  # V1.1
+        "StrategyCvxHelper": "0x9A12A9141363A5B343B781c4951d42E327B89397",  # V1.1
+        "StrategyCvxCrvHelper": "0x76328277232c97BAf76D23A69015CB478293A048",  # V1.1
         "KeeperAccessControl": "0x4fe70eE8fa906D59A88DE5946F114BdbFC410a80",
-        "native.vestedCVX": "0x86ca553D5Ae7cD0005552D6E275786D5043800Bd", # V1.7.1 - Change bribes processor address
+        "native.vestedCVX": "0x86ca553D5Ae7cD0005552D6E275786D5043800Bd",  # V1.7.1 - Change bribes processor address
+        "native.graviAURA": "0x7C2a951d062cC7B7C6F9C7Aa7e80a6f20EAA8caB",  # V1.2
         "RewardsRecoveryStrategy_distribution": "0xEDb5a82016c95B0F6099Ec51F463691Fa2ba02B9",
         "SettV1h": "0x9376B47E7eC9D4cfd5313Dc1FB0DFF4F61E8c481",
         "SettV1_1h_V1": "0x25c9BD2eE36ef38992f8a6BE4CadDA9442Bf4170",
         "SettV4h_V1": "0x0B7Cb84bc7ad4aF3E1C5312987B6E9A4612068AD",
-        "SettV1_1h_V2": "0x724f4153b3D69f64975f1B16cE4445fd7bC5C9a2", # V2 -> governanceOrStrategist approve/revoke + sweep
-        "SettV4h_V2": "0x4Da27cD2AE34a9E1776Ed01747A071C17Fa0b2Cf", # V2 -> governanceOrStrategist approve/revoke + sweep
-        "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9", # V1.1 -> Beneficiary: devMulti
-        "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C", # V1.1
-        "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa", # V1.1
+        "SettV1_1h_V2": "0x724f4153b3D69f64975f1B16cE4445fd7bC5C9a2",  # V2 -> governanceOrStrategist approve/revoke + sweep
+        "SettV4h_V2": "0x4Da27cD2AE34a9E1776Ed01747A071C17Fa0b2Cf",  # V2 -> governanceOrStrategist approve/revoke + sweep
+        "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9",  # V1.1 -> Beneficiary: devMulti
+        "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C",  # V1.1
+        "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa",  # V1.1
+        "SimpleWrapperGatedUpgradeable": "0x021ea7548Ee9B40d57f47706A605043B05C6c92C",
+        "TheVault": "0x60c796ACb2E0949178086294f03A44C450511784",  # V1.5.2.a
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",
@@ -318,7 +385,8 @@ ADDRESSES_ETH = {
         "bbveCVX-CVX-f": "0x0c41A8613fbeFCC8d6e5dF1020DBb336F875247F",
         "ibBTCCrv": "0xe505F7C2FFcce7Ae4b076456BC02A70D8fe8d4d2",
         "restitution": "0x3F61344BA56df00dad9bBcA05d98CA2AeC43Ba0B",
-        "badgerCrv_temp": "0xa54d8a596B4022CC4436b692C8ea0E342405eB6e"
+        "bcrvBadger": "0xa54d8a596B4022CC4436b692C8ea0E342405eB6e",
+        "dummy": "0xEC4bc89F35A7bf9ffe0375Fd67940Ded1e2253BF",
     },
     "yearn_vaults": {"byvWBTC": "0x4b92d19c11435614CD49Af1b589001b7c08cD4D5"},
     "peaks": {
@@ -360,16 +428,12 @@ ADDRESSES_ETH = {
         "native.sbtcCrv": "0xf1ded284e891943b3e9c657d7fc376b86164ffc2",
         "native.tbtcCrv": "0x522bb024c339a12be1a47229546f288c40b62d29",
         "native.hbtcCrv": "0xff26f400e57bf726822eacbb64fa1c52f1f27988",
-        "native.pbtcCrv": "0x1C1fD689103bbFD701b3B7D41A3807F12814033D",
-        "native.obtcCrv": "0x2bb864cdb4856ab2d148c5ca52dd7ccec126d138",
         "native.bbtcCrv": "0x4f3e7a4566320b2709fd1986f2e9f84053d3e2a0",
         "native.tricrypto2": "0x2eB6479c2f033360C0F4575A88e3b8909Cbc6a03",
         "native.renCrvV1.1": "0xe66dB6Eb807e6DAE8BD48793E9ad0140a2DEE22A",
         "native.sbtcCrvV1.1": "0x2f278515425c8eE754300e158116930B8EcCBBE1",
         "native.tbtcCrvV1.1": "0x9e0742EE7BECde52A5494310f09aad639AA4790B",
         "native.hbtcCrvV1.1": "0x7354D5119bD42a77E7162c8Afa8A1D18d5Da9cF8",
-        "native.pbtcCrvV1.1": "0x3f98F3a21B125414e4740316bd6Ef14718764a22",
-        "native.obtcCrvV1.1": "0x50Dd8A61Bdd11Cf5539DAA83Bc8E0F581eD8110a",
         "native.bbtcCrvV1.1": "0xf92660E0fdAfE945aa13616428c9fB4BE19f4d34",
         "native.tricrypto2V1.1": "0xf3202Aa2783F3DEE24a35853C6471db065B05D37",
     },
@@ -380,6 +444,7 @@ ADDRESSES_ETH = {
         "incentives_controller": "0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5",
         "aave_lending_pool_v2": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9",
         "data_provider": "0x057835Ad21a177dbdd3090bB1CAE03EaCF78Fc6d",
+        "price_oracle_v2": "0xA50ba011c48153De246E5192C8f9258A2ba79Ca9",
     },
     "cow": {
         "vault_relayer": "0xC92E8bdf79f0507f65a392b0ab4667716BFE0110",
@@ -395,36 +460,39 @@ ADDRESSES_ETH = {
         "booster": "0xF403C135812408BFbE8713b5A23a04b3D48AAE31",
         "claim_zap": "0x92Cf9E5e4D1Dfbf7dA0d2BB3e884a68416a65070",
         "vlCVX": "0xD18140b4B819b895A3dba5442F959fA44994AF50",
+        "frax": {
+            "booster": "0x569f5B842B5006eC17Be02B8b94510BA8e79FbCa",
+            "pool_registry": "0x41a5881c17185383e19Df6FA4EC158a6F4851A69",
+            "wcvx_badger_fraxbp": "0xb92e3fD365Fc5E038aa304Afe919FeE158359C88",
+            "private_vaults": {
+                "badger_fraxbp": "0xa895B89D74a6BC23a284a0526e123ea776674cF5",
+            },
+        },
     },
     "votium": {
+        "bribe": "0x19BBC3463Dd8d07f55438014b021Fb457EBD4595",
         "multiMerkleStash": "0x378Ba9B73309bE80BF4C2c027aAD799766a7ED5A",
     },
-    "bribe_tokens_claimable": {
-        "CVX": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+    "bribe_tokens_claimable_graviaura": {
         "BADGER": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
-        "DAI": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        "SPELL": "0x090185f2135308bad17527004364ebcc2d37e5f6",
-        "ALCX": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-        "NSBT": "0x9D79d5B61De59D882ce90125b18F74af650acB93",
-        "MATIC": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
-        "FXS": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+        "AURA": "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+        "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "SD": "0x30D20208d987713f46DFD34EF128Bb16C404D10f",
+        "DFX": "0x888888435FDe8e7d4c54cAb67f206e4199454c60",
+        "WETH": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "RPL": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+        "INV": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
         "LDO": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
-        "TRIBE": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
-        "OGN": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
-        "MTA": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
-        "ANGLE": "0x31429d1856aD1377A8A0079410B297e1a9e214c2",
-        "T": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
-        "UST": "0xa693B19d2931d498c5B318dF961919BB4aee87a5", # USTv2 (wormhole)
-        "LFT": "0xB620Be8a1949AA9532e6a3510132864EF9Bc3F82",
-        "FLX": "0x6243d8CEA23066d098a15582d81a598b4e8391F4",
-        "GRO": "0x3Ec8798B81485A254928B70CDA1cf0A2BB0B74D7",
+        "BAL": "0xba100000625a3754423978a60c9317c58a424e3D",
     },
     "uniswap": {
         "factoryV3": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
         "v3pool_wbtc_badger": "0xe15e6583425700993bd08F51bF6e7B73cd5da91B",
         "NonfungiblePositionManager": "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
         "routerV2": "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
+        "routerV3": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
         "factoryV2": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+        "quoter": "0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6",
     },
     "sushiswap": {
         "routerV2": "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F",
@@ -438,42 +506,89 @@ ADDRESSES_ETH = {
         "zap_ibbtc": "0xbba4b444FD10302251d9F5797E763b0d912286A1",
         "zap_pbtc": "0x11F419AdAbbFF8d595E7d5b223eee3863Bb3902C",
         "zap_obtc": "0xd5BCf53e2C81e1991570f33Fa881c49EEa570C8D",
+        "zap_fraxbp": "0x5De4EF4879F4fe3bBADF2227D2aC5d0E2D76C895",
     },
     "uma": {
         "DIGG_LongShortPair": "0x65DCcd928C71ef98e6eC887FEA24d116765c8A8D",
     },
-    "nft": {
-        "badger_jersey": "0xe1e546e25A5eD890DFf8b8D005537c0d373497F8"
-    },
+    "nft": {"badger_jersey": "0xe1e546e25A5eD890DFf8b8D005537c0d373497F8"},
     "arbitrum": {
         "outbox": "0x760723CD2e632826c38Fef8CD438A4CC7E7E1A40",
+        "l1_gateway": "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
+        "l1_erc20_gateway": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC",
     },
     "balancer": {
         "vault": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
         "gauge_factory": "0x4E7bBd911cf1EFa442BC1b2e9Ea01ffE785412EC",
         "B_50_BTC_50_WETH": "0xA6F548DF93de924d73be7D25dC02554c6bD66dB5",
-        "B_20_BTC_80_BADGER_GAUGE": "0xAF50825B010Ae4839Ac444f6c12D44b96819739B",
+        "B_20_BTC_80_BADGER_GAUGE": "0x3F29e69955E5202759208DD0C5E0BA55ff934814",
         "B_20_BTC_80_BADGER": "0xb460DAa847c45f1C4a41cb05BFB3b51c92e41B36",
         "B_3POOL": "0x06Df3b2bbB68adc8B0e302443692037ED9f91b42",
         "B_80_BAL_20_WETH": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
-        "veBAL": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
+        "BB_A_USD": "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2",
+        "B_auraBAL_STABLE": "0x3dd0843A028C86e0b760b1A76929d1C5Ef93a2dd",
+        "veBAL": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+        "minter": "0x239e55F427D44C3cc793f49bFB507ebe76638a2b",
+        "bpt_aurabal": "0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd",
+        "bpt_33_grav_33_weth_33_aura": "0xA3283E3470D3CD1F18C074E3f2d3965F6D62fFF2",
+        "bpt_33_grav_33_weth_33_aurabal": "0x0578292CB20a443bA1CdE459c985CE14Ca2bDEe5",
+        "bpt_40wbtc_40digg_20graviaura": "0x8eB6c82C3081bBBd45DcAC5afA631aaC53478b7C",
+        "B_50_BADGER_50_RETH": "0xe340EBfcAA544da8bB1Ee9005F1a346D50Ec422e",
+        "B_50_BADGER_50_RETH_GAUGE": "0xb32Ae42524d38be7E7eD9E02b5F9330fCEf07f3F",
+        "B_50_WETH_50_RETH": "0x1E19CF2D73a72Ef1332C882F20534B6519Be0276",
     },
     "hidden_hand": {
         "bribe_vault": "0x9DDb2da7Dd76612e0df237B89AF2CF4413733212",
         "tokenmak_briber": "0x7816b3D0935D668bCfc9A4aaB5a84EBc7fF320cf",
         "balancer_briber": "0x7Cdf753b45AB0729bcFe33DC12401E55d28308A9",
+        "rewards_distributor": "0x0b139682D5C9Df3e735063f46Fb98c689540Cf3A",
+        "aura_briber": "0x642c59937A62cf7dc92F70Fd78A13cEe0aa2Bd9c",
+        "frax_briber": "0x123683885310851Ca29e83AE3FF3e2490D4420Cd",
     },
     "chainlink": {
         "feed_registry": "0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf",
-        "keeper_registry": "0x7b3EC232b08BD7b4b3305BE0C044D907B2DF960B",
-        "upkeep_registration_requests": "0x09B1de9Ecf6600FD44e1cB1b46DF6B520f33ec6d",
+        "keeper_registry": "0x02777053d6764996e594c3E88AF1D58D5363a2e6",
+        "keeper_registrar": "0xDb8e8e2ccb5C033938736aa89Fe4fa1eDfD15a1d",
     },
     "across_bridge": {
         "hub_pool": "0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534",
     },
     "maker": {
         "proxy_registry": "0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4",
-    }
+    },
+    "gnosis": {
+        "sign_message_lib": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+    },
+    "aura": {
+        "wrapper": "0x68655AD9852a99C87C0934c7290BB62CFa5D4123",
+        "depositor": "0xeAd792B55340Aa20181A80d6a16db6A0ECd1b827",
+        "aurabal_staking": "0xC47162863a12227E5c3B0860715F9cF721651C0c",
+        "aurabal_rewards": "0x5e5ea2048475854a5702F5B8468A51Ba1296EFcC",
+        "vlAURA": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+        "merkle_drop": "0x45EB1A004373b1D8457134A2C04a42d69D287724",
+        "booster": "0x7818A1DA7BD1E64c199029E86Ba244a9798eEE10",
+        "claim_zap": "0x623B83755a39B12161A63748f3f595A530917Ab2",
+        "extra_rewards_distributor": "0xa3739b206097317c72ef416f0e75bb8f58fbd308",
+        "gauge_migrator": "0x7954bcDce86e86BeE7b1dEff48c3a0b9BCCe578B",
+        "aura_20wbtc80badger": "0x05df1E87f41F793D9e03d341Cdc315b76595654C",
+        "aura_20wbtc80badger_old": "0xCea3aa5b2a50e39c7C7755EbFF1e9E1e1516D3f5",
+        "aura_40wbtc40digg20gravi": "0xe86f0312b06126855810B4a13a43c3E2b1B8DD90",
+        "aura_40wbtc40digg20gravi_old": "0x10Ca519614b0F3463890387c24819001AFfC5152",
+    },
+    "ens": {
+        "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "public_resolver": "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
+    },
+    "ribbon": {
+        "badger_vault": "0x270F4a26a3fE5766CcEF9608718491bb057Be238",
+    },
+    "euler": {
+        "euler": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
+        "euler_markets": "0x3520d5a913427E6F0D6A83E07ccD4A4da316e4d3",
+    },
+    "frax": {
+        "BADGER_FRAXBP_GAUGE": "0x5a92EF27f4baA7C766aee6d751f754EBdEBd9fae",
+    },
 }
 
 ADDRESSES_IBBTC = {
@@ -493,9 +608,9 @@ ADDRESSES_IBBTC = {
     "bcrvTBTC": ADDRESSES_ETH["sett_vaults"]["bcrvTBTC"],
     "byvWBTC": ADDRESSES_ETH["yearn_vaults"]["byvWBTC"],
     "logic": {
-        "core": "0xafa40Da6a373eC4BBfdDAF2e695F3014aF5376c5", # Current logic
-        "badgerPeak": "0xbD82A0C250608543b8cAcfD4F0E4438438698df6", # Current logic
-        "byvWbtcPeak": "0xA9499b50C4A74000687435A895B55974F079ECaa", # Current logic
+        "core": "0xafa40Da6a373eC4BBfdDAF2e695F3014aF5376c5",  # Current logic
+        "badgerPeak": "0xbD82A0C250608543b8cAcfD4F0E4438438698df6",  # Current logic
+        "byvWbtcPeak": "0xA9499b50C4A74000687435A895B55974F079ECaa",  # Current logic
     },
     "sett_zap": "0x27Fb47B9Fb32B9cF660C4E0128bE0f4e883f3df1",
     "mint_zap": "0xe8E40093017A3A55B5c2BC3E9CA6a4d208c07734",
@@ -561,17 +676,28 @@ ADDRESSES_BSC = {
     "pancakeswap": {
         "router_v1": "0x05fF2B0DB69458A0750badebc4f9e13aDd608C7F",
         "router_v2": "0x10ED43C718714eb63d5aA57B78B54704E256024E",
-        "factory_v2": "0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73"
+        "factory_v2": "0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73",
     },
 }
 
 ADDRESSES_POLYGON = {
     "zero": "0x0000000000000000000000000000000000000000",
+    "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
+    "registryAccessControl": "0x9026B950085dcc72269cAc4a8Aa8385cc8A774Cd",
     "badger_wallets": {
         "badgertree": "0x2C798FaFd37C7DCdcAc2498e19432898Bc51376b",
         "rewardLogger": "0xd0EE2A5108b8800D688AbC834445fd03b3b2738e",
         "techops_multisig": "0xeb7341c89ba46CC7945f75Bd5dD7a04f8FA16327",
         "dev_multisig": "0x4977110Ed3CD5eC5598e88c8965951a47dd4e738",
+        "ops_deployer": "0xDA25ee226E534d868f0Dd8a459536b03fEE9079b",
+        "ops_deployer2": "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556",
+        "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
+        "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
+        "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
+        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+        "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
+        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
     },
     "treasury_tokens": {
         "BADGER": "0x1FcbE5937B0cc2adf69772D228fA4205aCF4D9b2",
@@ -599,6 +725,7 @@ ADDRESSES_POLYGON = {
     "opolis": {
         "stakingHelper": "0x8bF5aD0dBa1e29741740D96E55Bf27Aec30B18E2",
         "whitelist": "0x44a0487656420FDc15f9CA76dd95F3b8a2ef0Baa",
+        "magic_wallet": "0xb5a2AB06c9B096F1Ca892e42e786c2D6a8Bb4D46",
     },
     "registry": "0xFda7eB6f8b7a9e9fCFd348042ae675d1d652454f",
     "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
@@ -606,25 +733,37 @@ ADDRESSES_POLYGON = {
 
 ADDRESSES_ARBITRUM = {
     "zero": "0x0000000000000000000000000000000000000000",
+    "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
+    "registryAccessControl": "0x6847a17C4AC30AFd24FDcb2422DA01207C480a79",
+    "EmissionControl": "0x78418681f9ed228d627f785fb9607ed5175518fd",
     "badger_wallets": {
         "badgertree": "0x635EB2C39C75954bb53Ebc011BDC6AfAAcE115A6",
         "techops_multisig": "0x292549E6bd5a41aE4521Bb8679aDA59631B9eD4C",
         "techops_multisig_deprecated": "0xF6BC36280F32398A031A7294e81131aEE787D178",
         "dev_multisig": "0xb364bAb258ad35dd83c7dd4E8AC78676b7aa1e9F",
         "dev_multisig_deprecated": "0x468A0FF843BC5D185D7B07e4619119259b03619f",
+        "ops_deployer": "0xDA25ee226E534d868f0Dd8a459536b03fEE9079b",
         "ops_deployer2": "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556",
+        "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
+        "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+        "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
+        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
         "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
-        "ops_executor4": "0xBB2281cA5B4d07263112604D1F182AD0Ab26a252",
-        "ops_executor8": "0x10C7a2ca16116E5C998Bfa3BC9CEF464475B18ff",
+        "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
+        "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
         "ops_executor9": "0x69874C84a30A3742cC2b624238CfEEa24CF5eF82",
         "ops_executor10": "0xaF94D299a73c4545ff702E79D16d9fb1AB5BDAbF",
         "ops_executor11": "0x54cf9df9dcd78e470ab7cb892d7bfbe114c025fc",
+        "ops_executor13": "0x95c1D2014909c04202fa73820B894b45F054F25e",
         "ops_botsquad": "0xF8dbb94608E72A3C4cEeAB4ad495ac51210a341e",
         "ops_botsquad_cycle0": "0x1a6D6D120a7e3F71B084b4023a518c72F1a93EE9",
+        "_deprecated": {
+            "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+        },
     },
     "sett_vaults": {
         "bslpWbtcEth": "0xFc13209cAfE8fb3bb5fbD929eC9F11a39e8Ac041",
@@ -647,8 +786,8 @@ ADDRESSES_ARBITRUM = {
         "native.DXSIbbtcWeth": "0x4AeC063BB5322c9d4c1f46572f432aaE3b78b87c",
     },
     "logic": {
-        "native.renCrv": "0x021ea7548Ee9B40d57f47706A605043B05C6c92C", # v1.1
-        "native.tricrypto": "0x4Da27cD2AE34a9E1776Ed01747A071C17Fa0b2Cf", # v1.1
+        "native.renCrv": "0x021ea7548Ee9B40d57f47706A605043B05C6c92C",  # v1.1
+        "native.tricrypto": "0x4Da27cD2AE34a9E1776Ed01747A071C17Fa0b2Cf",  # v1.1
         "_deprecated": {
             "native.renCrv": {
                 "v1": "0x2eE1E845b601371608b6bA4a4665180dE3b14C85",
@@ -656,10 +795,10 @@ ADDRESSES_ARBITRUM = {
             "native.tricrypto": {
                 "v1": "0xd64E77C7C6A1dcC7e302F8fe31A22745e223c39c",
             },
-        }
+        },
     },
     "treasury_tokens": {
-        "BADGER" : "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
+        "BADGER": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E",
         "WBTC": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
         "CRV": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
         "SUSHI": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
@@ -708,17 +847,13 @@ ADDRESSES_ARBITRUM = {
         "bDXSWbtcWeth": "0x0c41A8613fbeFCC8d6e5dF1020DBb336F875247F",
     },
     "swapr_staking_contracts": {
-        "native.DXSSwaprWeth": "0x0934e27Eea82f720166eC37214C07e6777511D27",
-        "native.DXSWbtcWeth": "0x7d5Fb4C81df4115B2e4bB84e36cda8bE7aDF9B4F",
-        "native.DXSBadgerWeth": "0x42EcF352216b4Be82331123dbCee60447c91b70F",
-        "native.DXSIbbtcWeth": "0x13a22d37Dee5D6C99D4a36F50C2fD274F73Df21c",
+        "native.DXSSwaprWeth": "0x4595F4A294D5b40933c82E0dff02B7973853e801",
+        "native.DXSWbtcWeth": "0xEbcE743B5221CA9e9320864a9F635267B8eAD98A",
+        "native.DXSBadgerWeth": "0x693c7bf083aF4F1B8F90B376cd84F55Ca8612684",
+        "native.DXSIbbtcWeth": "0x24FC053c8A4932E91CFe9bde3992B26d26c5C818",
     },
-    "sushi": {
-        "router": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506"
-    },
-    "swapr": {
-        "router": "0x530476d5583724A89c8841eB6Da76E7Af4C0F17E"
-    },
+    "sushi": {"router": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506"},
+    "swapr": {"router": "0x530476d5583724A89c8841eB6Da76E7Af4C0F17E"},
     "arbitrum_node": "0x00000000000000000000000000000000000000C8",
     "arbitrum_gateway_router": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933",
     "controller": "0x3811448236d4274705b81C6ab99d617bfab617Cd",
@@ -749,11 +884,13 @@ ADDRESSES_RINKEBY = {
         "solo_multisig": "0x4e9B82f40a657105b083db308D33E93789329ddb",
         "gas_station": "0x747a4c9073B68AE16A29e65f4b95C9bbEa1E19cD",
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
-        "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
         "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
         "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",
-        "ops_executor8": "0x10C7a2ca16116E5C998Bfa3BC9CEF464475B18ff",
+        "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
         "ops_executor12": "0xD3cee5e327715Ad1195DcE8FD571c564cD2100E7",
+        "_deprecated": {
+            "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+        },
     },
     "treasury_tokens": {
         "WBTC": "0x577D296678535e4903D59A4C929B718e1D575e0A",
@@ -773,6 +910,8 @@ ADDRESSES_RINKEBY = {
 }
 
 ADDRESSES_FANTOM = {
+    "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
+    "registryAccessControl": "0x8E2d940114f4882Acc139A84362a45C5cA4B6a0d",
     "badger_wallets": {
         "badgertree": "0x89122c767a5f543e663db536b603123225bc3823",
         "dev_multisig": "0x4c56ee3295042f8A5dfC83e770a21c707CB46f5b",
@@ -781,16 +920,27 @@ ADDRESSES_FANTOM = {
         "treasury_vault_multisig": "0x45b798384c236ef0d78311D98AcAEc222f8c6F54",
         "ops_deployer": "0xDA25ee226E534d868f0Dd8a459536b03fEE9079b",
         "ops_deployer2": "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556",
+        "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
+        "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
+        "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+        "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
+        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
         "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
-        "ops_executor4": "0xBB2281cA5B4d07263112604D1F182AD0Ab26a252",
+        "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         "ops_executor6": "0x66496eBB9d848C6A8F19612a6Dd10E09954532D0",
         "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",
         "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
         "ops_botsquad": "0xF8dbb94608E72A3C4cEeAB4ad495ac51210a341e",
         "ops_botsquad_cycle0": "0x1a6D6D120a7e3F71B084b4023a518c72F1a93EE9",
+        "keeperAccessControl": "0x0680b32b52C5ca8C731490c0C576337058f39337",
+        "devProxyAdmin": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF",
+        "guardian": "0x576DFDEc454792773dD26a781177CF998aA832E3",
+        "_deprecated": {
+            "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+        },
     },
     "treasury_tokens": {
         "WFTM": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
@@ -799,12 +949,15 @@ ADDRESSES_FANTOM = {
         "OXD": "0xc5A9848b9d145965d821AaeC8fA32aaEE026492d",
         "BADGER": "0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
     },
-    "lp_tokens": {
-        "bveOXD-OXD": "0x6519546433dCB0a34A0De908e1032c46906EF664"
-    },
+    "lp_tokens": {"bveOXD-OXD": "0x6519546433dCB0a34A0De908e1032c46906EF664"},
     "sett_vaults": {
         "bveOXD": "0x96d4dBdc91Bef716eb407e415c9987a9fAfb8906",
-        "bbveOXD-OXD": "0xbF2F3a9ba42A00CA5B18842D8eB1954120e4a2A9"
+        "bbveOXD_OXD": "0xbF2F3a9ba42A00CA5B18842D8eB1954120e4a2A9",
+        "bwFTM-WETH-wBTC": "0x5dA75c76565B69A5cDC5F2195E31362CEA00CD14",
+    },
+    "strategies": {
+        "native.vestedOXD": "0x0c7E0807011A218d0F1A156D3965875ff233933E",
+        "native.bveOXD-OXD": "0x00B154A7fBF57a09DeeC960f152205d5aE9795AE",
     },
     "solidly": {
         "router": "0xa38cd27185a464914D3046f0AB9d43356B34829D",
@@ -812,15 +965,52 @@ ADDRESSES_FANTOM = {
     },
     "spookyswap": {
         "router": "0xF491e7B69E4244ad4002BC14e878a34207E38c29",
-        "factory": "0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3"
+        "factory": "0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3",
     },
     "registry": "0xFda7eB6f8b7a9e9fCFd348042ae675d1d652454f",
     "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
     "rewardsLogger": "0xaB2F5E2709286aCe1863DF8ee55475482781F68C",
     "governance_timelock": "0x5ddE67e4f0abD7a94E99C037A04A1946f9DbaA36",
-    "keeperAccessControl": "0x0680b32b52C5ca8C731490c0C576337058f39337",
-    "devProxyAdmin": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF",
-    "guardian": "0x576DFDEc454792773dD26a781177CF998aA832E3",
+    "logic": {
+        "theVaultWithoutTree": "0xEf919733Eeb7326c5389f4a5D7337cdF078b0db9",
+        "StrategybveOxdOxdStakingOptimizer": "0x5Eb4e278d54Ade50bDfb305c698A7640944bd7dc",  # V1.1
+    },
+}
+
+ADDRESSES_OPTIMISM = {
+    "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
+    "registryAccessControl": "0xEa8567d84E3e54B32176418B4e0C736b56378961",
+    "badger_wallets": {
+        "dev_multisig": "0x0D5eDB3ECbB15EF4EaD105c018fEd4e1d173B335",
+        "techops_multisig": "0x8D05c5DA2a3Cb4BeB4C5EB500EE9e3Aa71670733",
+        "devProxyAdmin": "0x52FE2D2332FFCE104959DabF45383c6F25c3C21b",
+        "ops_deployer": "0xDA25ee226E534d868f0Dd8a459536b03fEE9079b",
+        "ops_deployer2": "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556",
+        "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
+        "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
+        "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
+        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+        "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
+        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
+    },
+}
+
+ADDRESSES_KOVAN = {
+    "treasury_tokens": {
+        "WETH": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "BAL": "0xcb355677E36f390Ccc4a5d4bEADFbF1Eb2071c81",
+    },
+    "aura": {
+        "wrapper": "0x04Cad0f53D69Ad75e3cC42F86405223783BCdd8E",
+        "depositor": "0xc8362A7454eE6f400d0376D37C703Fbd8BCC22e8",
+    },
+}
+
+ADDRESSES_GOERLI = {
+    "badger_wallets": {
+        "test_multisig": "0xfA87ce273f8C254F345Bc7de42F30e2d2FEe6779",
+    }
 }
 
 
@@ -839,20 +1029,25 @@ def checksum_address_dict(addresses):
     return checksummed
 
 
-with open('helpers/chaindata.json') as chaindata:
+with open("helpers/chaindata.json") as chaindata:
     chain_ids = json.load(chaindata)
 
 
-registry = DotMap({
-    "eth": checksum_address_dict(ADDRESSES_ETH),
-    "ibbtc": checksum_address_dict(ADDRESSES_IBBTC),
-    "bsc": checksum_address_dict(ADDRESSES_BSC),
-    "bridge": checksum_address_dict(ADDRESSES_BRIDGE),
-    "poly": checksum_address_dict(ADDRESSES_POLYGON),
-    "arbitrum": checksum_address_dict(ADDRESSES_ARBITRUM),
-    "rinkeby": checksum_address_dict(ADDRESSES_RINKEBY),
-    "ftm": checksum_address_dict(ADDRESSES_FANTOM),
-})
+registry = DotMap(
+    {
+        "eth": checksum_address_dict(ADDRESSES_ETH),
+        "ibbtc": checksum_address_dict(ADDRESSES_IBBTC),
+        "bsc": checksum_address_dict(ADDRESSES_BSC),
+        "bridge": checksum_address_dict(ADDRESSES_BRIDGE),
+        "poly": checksum_address_dict(ADDRESSES_POLYGON),
+        "arbitrum": checksum_address_dict(ADDRESSES_ARBITRUM),
+        "rinkeby": checksum_address_dict(ADDRESSES_RINKEBY),
+        "ftm": checksum_address_dict(ADDRESSES_FANTOM),
+        "op": checksum_address_dict(ADDRESSES_OPTIMISM),
+        "kovan": checksum_address_dict(ADDRESSES_KOVAN),
+        "goerli": checksum_address_dict(ADDRESSES_GOERLI),
+    }
+)
 
 
 def get_registry():
@@ -866,6 +1061,12 @@ def get_registry():
         return registry.arbitrum
     elif chain.id == 250:
         return registry.ftm
+    elif chain.id == 10:
+        return registry.op
+    elif chain.id == 42:
+        return registry.kovan
+    elif chain.id == 5:
+        return registry.goerli
 
 
 try:

--- a/scripts/refillers/deploy_autonomous_dripper.py
+++ b/scripts/refillers/deploy_autonomous_dripper.py
@@ -3,36 +3,37 @@ from datetime import date, timedelta
 
 from brownie import AutonomousDripper, accounts, chain, network
 
-from helpers.addresses import registry
+from helpers.addresses import r
 
 
 def main(deployer_label=None):
     deployer = accounts[0] if not deployer_label else accounts.load(deployer_label)
-    on_live_network = not '-fork' in network.show_active()
+    on_live_network = not "-fork" in network.show_active()
     if chain.id == 1:
         return AutonomousDripper.deploy(
-            registry.eth.badger_wallets.techops_multisig, # address initialOwner
-            registry.eth.badger_wallets.badgertree, # address beneficiaryAddress
-            timegm(date(2022, 7, 1).timetuple()), # uint64 startTimestamp
-            int(timedelta(weeks=13).total_seconds()), # uint64 durationSeconds
-            60*60*24*7, # uint intervalSeconds
-            [registry.eth.treasury_tokens.BADGER], # address[] memory watchlistAddresses
-            registry.eth.chainlink.keeper_registry, # address keeperRegistryAddress
-            {'from': deployer},
-            publish_source=on_live_network
+            r.badger_wallets.techops_multisig,  # address initialOwner
+            r.sett_vaults.remBADGER,  # address beneficiaryAddress
+            timegm(date(2023, 1, 1).timetuple()),  # uint64 startTimestamp
+            int(timedelta(year=1).total_seconds()),  # uint64 durationSeconds
+            60 * 60 * 24 * 7,  # uint intervalSeconds
+            [r.treasury_tokens.BADGER],  # address[] memory watchlistAddresses
+            r.chainlink.keeper_registry,  # address keeperRegistryAddress
+            {"from": deployer},
+            publish_source=on_live_network,
         )
-    elif chain.id == 4:
-        return AutonomousDripper.deploy(
-            deployer,
-            registry.rinkeby.badger_wallets.solo_multisig,
-            timegm(date.today().timetuple()),
-            int(timedelta(weeks=1).total_seconds()),
-            60*60, # interval of one hour
-            [
-                registry.rinkeby.treasury_tokens.DAI,
-                registry.rinkeby.treasury_tokens.WBTC,
-            ],
-            registry.rinkeby.chainlink.keeper_registry,
-            {'from': deployer},
-            publish_source=on_live_network
-        )
+    # TODO: rinkeby no longer supported, use goerli instead
+    # elif chain.id == 4:
+    #     return AutonomousDripper.deploy(
+    #         deployer,
+    #         registry.rinkeby.badger_wallets.solo_multisig,
+    #         timegm(date.today().timetuple()),
+    #         int(timedelta(weeks=1).total_seconds()),
+    #         60 * 60,  # interval of one hour
+    #         [
+    #             registry.rinkeby.treasury_tokens.DAI,
+    #             registry.rinkeby.treasury_tokens.WBTC,
+    #         ],
+    #         registry.rinkeby.chainlink.keeper_registry,
+    #         {"from": deployer},
+    #         publish_source=on_live_network,
+    #     )

--- a/scripts/refillers/deploy_autonomous_dripper.py
+++ b/scripts/refillers/deploy_autonomous_dripper.py
@@ -14,7 +14,7 @@ def main(deployer_label=None):
             r.badger_wallets.techops_multisig,  # address initialOwner
             r.sett_vaults.remBADGER,  # address beneficiaryAddress
             timegm(date(2023, 1, 1).timetuple()),  # uint64 startTimestamp
-            int(timedelta(year=1).total_seconds()),  # uint64 durationSeconds
+            int(timedelta(days=365).total_seconds()),  # uint64 durationSeconds
             60 * 60 * 24 * 7,  # uint intervalSeconds
             [r.treasury_tokens.BADGER],  # address[] memory watchlistAddresses
             r.chainlink.keeper_registry,  # address keeperRegistryAddress


### PR DESCRIPTION
this time a single dripper for the whole of 2023 as agreed to by @sajanrajdev and @dapp-whisperer 

once deployed, will need a single topup of 75k * 4 = 300k badger and migration of the upkeep on the chainlink keeper registry; tracked through https://github.com/Badger-Finance/badger-multisig/issues/926